### PR TITLE
Fix XBuild Crash

### DIFF
--- a/Sugarcane/UFBG0201.SCX
+++ b/Sugarcane/UFBG0201.SCX
@@ -27,7 +27,6 @@ jmshine@ufl.edu
 *FIELDS
 @L ID_FIELD WSTA....  FLSA  FLOB  FLDT  FLDD  FLDS  FLST SLTX  SLDP  ID_SOIL    FLNAME
  1 GSFsec27 UFBG       -99   -99 DR001    75   200   -99 SL      75  UFBG760002 Shallow Muck
- 2 GSFsec27 FL06       -99   -99 DR001    75   200   -99 SL      75  UFBG760002 Shallow Muck
 @L ...........XCRD ...........YCRD .....ELEV .............AREA .SLEN .FLWR .SLAS FLHST FHDUR
  1             -99             -99       -99               -99   -99   -99   -99   -99   -99
  2             -99             -99       -99               -99   -99   -99   -99   -99   -99


### PR DESCRIPTION
Hi @chporter,

The Xbuild crashes when I try to open this default XFile (Sugarcane/UFBG0201.SCX) through the DSSAT's GUI (v47). When I removed this duplicated and unnecessary field the problem is sorted.

If you run into the same problem, please consider incorporating this fix too.

Cheers,